### PR TITLE
セクション更新時に順序が変わる不具合を修正

### DIFF
--- a/src/main/kotlin/com/j15/backend/infrastructure/persistence/jpa/JpaSectionRepository.kt
+++ b/src/main/kotlin/com/j15/backend/infrastructure/persistence/jpa/JpaSectionRepository.kt
@@ -6,8 +6,8 @@ import org.springframework.data.jpa.repository.Query
 
 interface JpaSectionRepository : JpaRepository<SectionEntity, Int> {
 
-    /** 指定題材のセクション一覧を取得 */
-    fun findBySubjectId(subjectId: Long): List<SectionEntity>
+    /** 指定題材のセクション一覧を取得（sectionId昇順） */
+    fun findBySubjectIdOrderBySectionIdAsc(subjectId: Long): List<SectionEntity>
 
     /** 指定題材のセクション数をカウント */
     fun countBySubjectId(subjectId: Long): Long

--- a/src/main/kotlin/com/j15/backend/infrastructure/persistence/repository/SectionRepositoryImpl.kt
+++ b/src/main/kotlin/com/j15/backend/infrastructure/persistence/repository/SectionRepositoryImpl.kt
@@ -18,7 +18,7 @@ class SectionRepositoryImpl(private val jpaSectionRepository: JpaSectionReposito
     }
 
     override fun findAllBySubjectId(subjectId: SubjectId): List<Section> {
-        return jpaSectionRepository.findBySubjectId(subjectId.value).map {
+        return jpaSectionRepository.findBySubjectIdOrderBySectionIdAsc(subjectId.value).map {
             SectionConverter.toDomain(it)
         }
     }


### PR DESCRIPTION
## Summary
- セクション一覧取得時にsectionIdの昇順でソートするよう修正
- セクション更新後も1→2→3の順序が保たれるようになります

## 変更内容
- `JpaSectionRepository.findBySubjectId` を `findBySubjectIdOrderBySectionIdAsc` に変更
- セクション取得時に常にsectionIdでソートされるようになりました

## 修正した問題
セクションを更新すると、次回取得時に順序が変わってしまう不具合を修正しました。
例: 更新前 1 → 2 → 3、セクション2を更新後 1 → 3 → 2 となっていた問題

## Test plan
- [x] セクション一覧が常にsectionId順で取得されることを確認
- [x] セクション更新後も順序が維持されることを確認
- [x] 既存の機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)