### PR TITLE
削除機能の修正

### DIFF
--- a/src/main/kotlin/com/j15/backend/application/usecase/subject/SectionUseCase.kt
+++ b/src/main/kotlin/com/j15/backend/application/usecase/subject/SectionUseCase.kt
@@ -73,4 +73,29 @@ class SectionUseCase(
 
         return sectionRepository.save(updatedSection)
     }
+
+    /** セクションを削除（管理者用） */
+    fun deleteSection(subjectId: SubjectId, sectionId: SectionId) {
+        // 題材の存在確認
+        if (!subjectRepository.existsById(subjectId)) {
+            throw IllegalArgumentException("題材が見つかりません: ${subjectId.value}")
+        }
+
+        // セクションの存在確認
+        if (!sectionRepository.existsById(subjectId, sectionId)) {
+            throw IllegalArgumentException("セクションが見つかりません: ${sectionId.value}")
+        }
+
+        sectionRepository.deleteById(subjectId, sectionId)
+    }
+
+    /** 指定した題材の全セクションを削除（管理者用） */
+    fun deleteAllSectionsBySubjectId(subjectId: SubjectId) {
+        // 題材の存在確認
+        if (!subjectRepository.existsById(subjectId)) {
+            throw IllegalArgumentException("題材が見つかりません: ${subjectId.value}")
+        }
+
+        sectionRepository.deleteAllBySubjectId(subjectId)
+    }
 }

--- a/src/main/kotlin/com/j15/backend/application/usecase/subject/SubjectUseCase.kt
+++ b/src/main/kotlin/com/j15/backend/application/usecase/subject/SubjectUseCase.kt
@@ -2,6 +2,7 @@ package com.j15.backend.application.usecase.subject
 
 import com.j15.backend.domain.model.subject.Subject
 import com.j15.backend.domain.model.subject.SubjectId
+import com.j15.backend.domain.repository.SectionRepository
 import com.j15.backend.domain.repository.SubjectRepository
 import java.time.Instant
 import org.springframework.stereotype.Service
@@ -10,7 +11,10 @@ import org.springframework.transaction.annotation.Transactional
 /** 題材管理ユースケース 題材（学習プロジェクト）のCRUD操作を提供 */
 @Service
 @Transactional
-class SubjectUseCase(private val subjectRepository: SubjectRepository) {
+class SubjectUseCase(
+        private val subjectRepository: SubjectRepository,
+        private val sectionRepository: SectionRepository
+) {
 
     /**
      * maxSectionsパラメータのバリデーション
@@ -106,6 +110,9 @@ class SubjectUseCase(private val subjectRepository: SubjectRepository) {
         if (!subjectRepository.existsById(id)) {
             throw IllegalArgumentException("題材が見つかりません: $subjectId")
         }
+        // 関連するセクションをすべて削除
+        sectionRepository.deleteAllBySubjectId(id)
+        // 題材を削除
         subjectRepository.deleteById(id)
     }
 

--- a/src/main/kotlin/com/j15/backend/domain/repository/SectionRepository.kt
+++ b/src/main/kotlin/com/j15/backend/domain/repository/SectionRepository.kt
@@ -11,4 +11,6 @@ interface SectionRepository {
     fun save(section: Section): Section
     fun existsById(subjectId: SubjectId, sectionId: SectionId): Boolean
     fun countBySubjectId(subjectId: SubjectId): Int // 題材ごとのセクション総数
+    fun deleteById(subjectId: SubjectId, sectionId: SectionId)
+    fun deleteAllBySubjectId(subjectId: SubjectId)
 }

--- a/src/main/kotlin/com/j15/backend/infrastructure/persistence/jpa/JpaSectionRepository.kt
+++ b/src/main/kotlin/com/j15/backend/infrastructure/persistence/jpa/JpaSectionRepository.kt
@@ -17,4 +17,7 @@ interface JpaSectionRepository : JpaRepository<SectionEntity, Int> {
             "SELECT s FROM SectionEntity s WHERE s.subjectId = :subjectId AND s.sectionId = :sectionId"
     )
     fun findBySubjectIdAndSectionId(subjectId: Long, sectionId: Int): SectionEntity?
+
+    /** 指定題材の全セクションを削除 */
+    fun deleteBySubjectId(subjectId: Long)
 }

--- a/src/main/kotlin/com/j15/backend/infrastructure/persistence/repository/SectionRepositoryImpl.kt
+++ b/src/main/kotlin/com/j15/backend/infrastructure/persistence/repository/SectionRepositoryImpl.kt
@@ -37,4 +37,13 @@ class SectionRepositoryImpl(private val jpaSectionRepository: JpaSectionReposito
     override fun countBySubjectId(subjectId: SubjectId): Int {
         return jpaSectionRepository.countBySubjectId(subjectId.value).toInt()
     }
+
+    override fun deleteById(subjectId: SubjectId, sectionId: SectionId) {
+        val sectionEntity = jpaSectionRepository.findBySubjectIdAndSectionId(subjectId.value, sectionId.value)
+        sectionEntity?.let { jpaSectionRepository.delete(it) }
+    }
+
+    override fun deleteAllBySubjectId(subjectId: SubjectId) {
+        jpaSectionRepository.deleteBySubjectId(subjectId.value)
+    }
 }

--- a/src/main/kotlin/com/j15/backend/presentation/controller/subject/SectionCommandController.kt
+++ b/src/main/kotlin/com/j15/backend/presentation/controller/subject/SectionCommandController.kt
@@ -130,4 +130,29 @@ class SectionCommandController(
                     .body(mapOf("error" to "セクションの更新中にエラーが発生しました"))
         }
     }
+
+    /**
+     * セクションを削除
+     */
+    @DeleteMapping("/{sectionId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    fun deleteSection(
+            @PathVariable subjectId: Long,
+            @PathVariable sectionId: Int,
+            @AuthenticationPrincipal userId: String
+    ): ResponseEntity<Void> {
+        return try {
+            sectionUseCase.deleteSection(
+                    subjectId = SubjectId(subjectId),
+                    sectionId = SectionId(sectionId)
+            )
+            ResponseEntity.noContent().build()
+        } catch (e: IllegalArgumentException) {
+            logger.warn("セクション削除エラー: ${e.message}", e)
+            ResponseEntity.notFound().build()
+        } catch (e: Exception) {
+            logger.error("予期しないエラー: ${e.message}", e)
+            ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build()
+        }
+    }
 }


### PR DESCRIPTION
### 実装内容
1. セクション削除メソッドの実装
SectionRepository にインターフェースメソッドを追加
JpaSectionRepository に JPA メソッドを追加
SectionRepositoryImpl に削除実装を追加

2. セクション削除ユースケースの実装
SectionUseCase に削除メソッドを追加

3. セクション削除エンドポイントの追加
SectionCommandController に DELETE メソッドを追加
エンドポイント: DELETE /api/sections/{sectionId}

4. 題材削除機能の改善
SubjectUseCase の deleteSubject メソッドを改善し、題材削除時に関連するすべてのセクションを自動削除するようにしました
データベース整合性の保証

5. Multipart バインドエラーの確認
CreateSectionRequest と UpdateSectionRequest が var プロパティを持つクラスであることを確認
コントローラ側で null チェックが実装されていることを確認
これらの修正により、DELETE /api/subjects/{subjectId} を実行する際に、関連するセクションが正しく削除され、サーバーエラーが発生しなくなります。